### PR TITLE
Flower shop reset and cuttable flower sorting order

### DIFF
--- a/Assets/Scripts/DynamicCutting/CuttableFlower.cs
+++ b/Assets/Scripts/DynamicCutting/CuttableFlower.cs
@@ -95,6 +95,7 @@ public class CuttableFlower : MonoBehaviour
         {
             renderers[i].sprite = FlowerShopManager.GetFlowerTopSprite(FlowerShopManager.GetCurrentFlower().flowerType);
             renderers[i+1].sprite = FlowerShopManager.GetFlowerBottomSprite(FlowerShopManager.GetCurrentFlower().flowerType);
+            renderers[i + 1].sortingOrder = 1;
         }
     }
 

--- a/Assets/Scripts/Managers/FlowerShopManager.cs
+++ b/Assets/Scripts/Managers/FlowerShopManager.cs
@@ -150,10 +150,13 @@ public class FlowerShopManager : MonoBehaviour
         return Instance.flowerBottomSprites[(int)t];
     }
 
-    public static void ResetFlowerShop()
+    /// <summary>
+    /// Resets the current flower and order to -1 after the minigames all end for the demo
+    /// </summary>
+    public void ResetFlowerShop()
     {
-        currentFlower = 0;
-        currentOrder = 0;
+        currentFlower = -1;
+        currentOrder = -1;
     }
 
     void Start()
@@ -170,7 +173,7 @@ public class FlowerShopManager : MonoBehaviour
     /// <param name="state">The enum state to change to</param>
     public void NextMinigame()
     {
-        Debug.Log(currentMinigame);
+        Debug.Log("Minigame: " + currentMinigame);
 
         if (currentMinigame < 0 || minigames[currentMinigame].GetType() != typeof(InteractManager))
         {
@@ -186,7 +189,11 @@ public class FlowerShopManager : MonoBehaviour
             //If the current minigame is higher or equal to the number of minigames, continue
             if (currentMinigame >= minigames.Count)
             {
+                CutManager cm = gameObject.AddComponent(typeof(CutManager)) as CutManager;
+                cm.ResetCutManager();
+                ResetFlowerShop();
                 SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
+
                 return;
 
                 // TODO: We're done, end the game (or memory)!!!

--- a/Assets/Scripts/Minigames/CutManager.cs
+++ b/Assets/Scripts/Minigames/CutManager.cs
@@ -56,6 +56,11 @@ public class CutManager : MinigameBehavior
         }
     }
 
+    public void ResetCutManager()
+    {
+        isFirstDethorn = true;
+    }
+
     public override void StopMinigame()
     {
         gameObject.SetActive(false);

--- a/Assets/Scripts/RestartGame.cs
+++ b/Assets/Scripts/RestartGame.cs
@@ -15,6 +15,6 @@ public class RestartGame : MonoBehaviour
     void StartGame()
     {
         SceneManager.LoadScene(0);
-        FlowerShopManager.ResetFlowerShop();
+        //FlowerShopManager.ResetFlowerShop(); error message, doesn't run anyway
     }
 }


### PR DESCRIPTION
Flower shop memory now resets properly and the flower stems in the trimming minigame are now layered behind the flower tops.